### PR TITLE
Make upstreams unique per lb group

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,7 @@ suites:
       - recipe[nginx]
       - recipe[baragon::service]
       - recipe[baragon::agent]
+      - recipe[test_baragon_lb::default]
     attributes:
       baragon:
         mocking: true
@@ -47,6 +48,7 @@ suites:
       - recipe[nginx]
       - recipe[baragon::service]
       - recipe[baragon::agent]
+      - recipe[test_baragon_lb::default]
     attributes:
       baragon:
         mocking: true

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,6 @@ metadata
 
 group :integration do
   cookbook 'nginx'
+  cookbook 'test_baragon_lb', path: 'test/integration/cookbooks/test_baragon_lb'
   cookbook 'zookeeper', '~> 3.0'
 end

--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -54,7 +54,7 @@ location {{{service.options.nginxLocationModifier}}} {{{service.serviceBasePath}
   {{#if service.options.nginxProxyPassOverride}}
   proxy_pass http://{{{service.options.nginxProxyPassOverride}}};
   {{else}}
-  proxy_pass http://baragon_{{{service.serviceId}}};
+  proxy_pass http://baragon_<%= group %>_{{{service.serviceId}}};
   {{/if}}
   proxy_connect_timeout {{firstOf service.options.nginxProxyConnectTimeout 55}};
   proxy_read_timeout {{firstOf service.options.nginxProxyReadTimeout 60}};
@@ -89,7 +89,7 @@ default['baragon']['templates']['upstream_template']['template'] = "
 {{/if}}
 
 {{#if upstreams}}
-upstream baragon_{{{service.serviceId}}} {
+upstream baragon_<%= group %>_{{{service.serviceId}}} {
   {{#each upstreams}}server {{{upstream}}};  # {{{requestId}}}
   {{/each}}
   {{#if service.options.nginxExtraUpstreamConfigs}}

--- a/resources/agent.rb
+++ b/resources/agent.rb
@@ -37,6 +37,9 @@ action :create do
   agent_yaml['loadBalancerConfig']['rootPath'] = agent_root_path
   agent_yaml['templates'] = templates || node['baragon']['templates'].to_hash.values
 
+  # Process the templates as ERB
+  agent_yaml['templates'].each { |item| item['template'] = ERB.new(item['template']).result(binding) }
+
   # Set the zk hosts and namespace.  These get set in baragon::common
   agent_yaml['zookeeper']['quorum'] = node['baragon']['zk_hosts'].join(',')
   agent_yaml['zookeeper']['zkNamespace'] = node['baragon']['zk_namespace']

--- a/test/integration/cookbooks/test_baragon_lb/libraries/helpers.rb
+++ b/test/integration/cookbooks/test_baragon_lb/libraries/helpers.rb
@@ -1,0 +1,51 @@
+module Baragon
+  module Helpers
+    def create_test_zk_request
+      require 'net/http'
+
+      return if test_request_exist?
+
+      lb_request = {
+        'loadBalancerRequestId' => "lbreq-#{Time.now.to_i}",
+        'loadBalancerService' => {
+          'serviceId' => 'tk-test-service',
+          'owners' => ['eric.herot@evertrue.com'],
+          'serviceBasePath' => '/testbasepath1',
+          'loadBalancerGroups' => ['default'],
+          'options' => {}
+        },
+        'addUpstreams' => [{
+          'upstream' => 'localhost:8123',
+          'requestId' => "upstreamreq-#{Time.now.to_i}",
+          'rackId' => 'us-east-1a',
+          'group' => 'default'
+        }],
+        'removeUpstreams' => []
+      }
+
+      uri = URI 'http://localhost:8088/baragon/v2/request'
+      req = Net::HTTP::Post.new uri
+      req.body = lb_request.to_json
+      req.content_type = 'application/json'
+
+      Net::HTTP.start(uri.hostname, uri.port) { |http| http.request req }
+
+      sleep 0.25 while JSON.parse(Net::HTTP.get(URI('http://localhost:8088/baragon/v2/request'))).any?
+    end
+
+    def test_request_exist?
+      tries = 0
+      begin
+        Net::HTTP.get_response(URI('http://localhost:8088/baragon/v2/state/tk-test-service'))
+                 .code.to_i == 200
+      rescue Errno::ECONNREFUSED => e
+        Chef::Log.info "Baragon connection refused. Retrying (#{tries})."
+        # The Baragon service doesn't necessarily start up instantly at bootstrap
+        tries += 1
+        sleep 1
+        retry if tries < 60
+        raise e
+      end
+    end
+  end
+end

--- a/test/integration/cookbooks/test_baragon_lb/metadata.rb
+++ b/test/integration/cookbooks/test_baragon_lb/metadata.rb
@@ -1,0 +1,2 @@
+name 'test_baragon_lb'
+version '1.0.1'

--- a/test/integration/cookbooks/test_baragon_lb/recipes/default.rb
+++ b/test/integration/cookbooks/test_baragon_lb/recipes/default.rb
@@ -1,0 +1,7 @@
+Chef::Resource.send(:include, Baragon::Helpers)
+
+ruby_block 'create test zk request' do
+  block { create_test_zk_request }
+  action :nothing
+  subscribes :run, 'service[baragon-server]'
+end

--- a/test/integration/helpers/serverspec/common/default.rb
+++ b/test/integration/helpers/serverspec/common/default.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+shared_examples_for 'default installation' do
+  it 'is running and enabled' do
+    expect(service('baragon-agent-default')).to be_enabled
+    # Note that the test service is expected to be "running" (strictly speaking)
+    # but it won't actually be working (e.g. listening on port 8882) because it
+    # will not start up completely when it is unable to reach Zookeeper.
+    expect(service('baragon-agent-default')).to be_running
+  end
+
+  describe file '/etc/baragon/agent-default.yml' do
+    it { is_expected.to be_file }
+
+    describe '#content' do
+      subject { super().content }
+      it { is_expected.to match 'sessionTimeoutMillis: 50000' }
+      it { is_expected.to_not match '!ruby/hash:Chef::Node::Immutable' }
+    end
+  end
+end

--- a/test/integration/helpers/serverspec/common/default.rb
+++ b/test/integration/helpers/serverspec/common/default.rb
@@ -14,6 +14,7 @@ shared_examples_for 'default installation' do
 
     describe '#content' do
       subject { super().content }
+      it { is_expected.to include 'upstream baragon_default_{{{service.serviceId}}}' }
       it { is_expected.to match 'sessionTimeoutMillis: 50000' }
       it { is_expected.to_not match '!ruby/hash:Chef::Node::Immutable' }
     end

--- a/test/integration/localzk/serverspec/agent_spec.rb
+++ b/test/integration/localzk/serverspec/agent_spec.rb
@@ -6,4 +6,26 @@ describe 'Baragon agent' do
   describe port 8882 do
     it { is_expected.to be_listening }
   end
+
+  describe 'dynamic proxies and upstreams created correctly' do
+    describe file '/tmp/default/proxy/tk-test-service.conf' do
+      it { is_expected.to be_file }
+
+      describe '#content' do
+        subject { super().content }
+        it { is_expected.to match(%r(^location  /testbasepath1 {$)) }
+        it { is_expected.to match(%r{^  proxy_pass http://baragon_default_tk-test-service;}) }
+      end
+    end
+
+    describe file '/tmp/default/upstreams/tk-test-service.conf' do
+      it { is_expected.to be_file }
+
+      describe '#content' do
+        subject { super().content }
+        it { is_expected.to match(/^upstream baragon_default_tk-test-service {$/) }
+        it { is_expected.to match(/^  server localhost:8123/) }
+      end
+    end
+  end
 end

--- a/test/integration/localzk/serverspec/agent_spec.rb
+++ b/test/integration/localzk/serverspec/agent_spec.rb
@@ -1,22 +1,9 @@
-require 'spec_helper'
+require 'common/default'
 
 describe 'Baragon agent' do
-  it 'is listening on the specified port' do
-    expect(port 8882).to be_listening
-  end
+  it_behaves_like 'default installation'
 
-  it 'is running and enabled' do
-    expect(service('baragon-agent-default')).to be_enabled
-    expect(service('baragon-agent-default')).to be_running
-  end
-
-  describe file '/etc/baragon/agent-default.yml' do
-    it { is_expected.to be_file }
-
-    describe '#content' do
-      subject { super().content }
-      it { is_expected.to_not match '!ruby/hash:Chef::Node::Immutable' }
-      it { is_expected.to match 'sessionTimeoutMillis: 50000' }
-    end
+  describe port 8882 do
+    it { is_expected.to be_listening }
   end
 end

--- a/test/integration/remotezk/serverspec/agent_spec.rb
+++ b/test/integration/remotezk/serverspec/agent_spec.rb
@@ -1,16 +1,15 @@
-require 'spec_helper'
+require 'common/default'
 
 describe 'Baragon agent' do
-  describe file('/etc/baragon/agent-default.yml') do
-    it { is_expected.to be_file }
+  it_behaves_like 'default installation'
 
+  describe file('/etc/baragon/agent-default.yml') do
     describe '#content' do
       subject { super().content }
       it do
         is_expected.to match('zookeeper-1.vagrantup.com:2181,' \
                              'zookeeper-2.vagrantup.com:2181')
       end
-      it { is_expected.to_not match '!ruby/hash:Chef::Node::Immutable' }
     end
   end
 end


### PR DESCRIPTION
The add-an-upstream test that I created may not actually work on first convergence for order-of-operations reasons but I didn't want this very important feature to be held up any more because of that.