### PR TITLE
Use Java 8

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,4 +7,4 @@ default['baragon']['git_ref'] = 'Baragon-0.4.0'
 default['baragon']['git_repo_url'] = 'https://github.com/HubSpot/Baragon.git'
 default['baragon']['install_type'] = 'package'
 
-default['java']['jdk_version'] = 7
+default['java']['jdk_version'] = 8


### PR DESCRIPTION
HubSpot is building Singularity & Baragon against Java 8, and the cookbook should follow suit.